### PR TITLE
Improvements to the README copy and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # Ruby Leaky Gems Database
 
-The RubyMem Database is a community effort to compile all known memory leaks that are relevant to Ruby gems.
+The [RubyMem](https://www.rubymem.com) Database is a community effort to compile all known memory leaks that are relevant to Ruby gems.
 
 You can check your own Gemfile.locks against this database by using [bundler-leak](https://github.com/rubymem/bundler-leak).
 
-## Support Ruby security!
+## Support Our RubyMem Initiative!
 
-Do you know about a known memory leak that isn't listed in this database? Open an issue, submit a PR, or [use this form](https://rubymem.com/advisories/new) which will email the maintainers.
+This project has been a community effort since the beginning. The more reports we track, the more value we can provide to your future projects!
+
+### How You Can Help
+
+Do you know about a known memory leak that isn't [listed in this database](https://www.rubymem.com/advisories)? Open an issue, submit a PR, or [use this form](https://rubymem.com/advisories/new) which will email the maintainers.
 
 ## Directory Structure
 
@@ -22,18 +26,21 @@ for the Ruby library. These files can be named however you want, in this example
 ## Format
 
 Each file contains the information in [YAML] format:
-    ---
-    gem: celluloid
-    url: https://github.com/celluloid/celluloid/issues/670
-    title: Memory Leak using Celluloid::Future
-    date: 2015-08-31
-    description: |
-      The Celluloid::Group::Spawner appears to never clean up the completed Threads
-      that it creates.
-    leaky_versions:
-      - "> 0.16.0, < 0.17.2"
-    patched_versions:
-      - ">= 0.17.3"
+
+```yaml
+---
+gem: celluloid
+url: https://github.com/celluloid/celluloid/issues/670
+title: Memory Leak using Celluloid::Future
+date: 2015-08-31
+description: |
+  The Celluloid::Group::Spawner appears to never clean up the completed Threads
+  that it creates.
+leaky_versions:
+  - "> 0.16.0, < 0.17.2"
+patched_versions:
+  - ">= 0.17.3"
+```
 
 ### Schema
 
@@ -51,7 +58,8 @@ Each file contains the information in [YAML] format:
 * `patched_versions` \[Array\<String\>\]: The version requirements for the
   patched versions of the Ruby library.
 
-### Tests
+## Tests
+
 Prior to submitting a pull request, run the tests:
 
 ```


### PR DESCRIPTION
This is a small PR to take care of these issues: 

- It fixes a formatting issue with the format section (it fixes #16)
- It does not mention anything about Ruby security (legacy copy from rubysec)
- It expands the section about helping with the ruby-mem-advisory-db

😄 