### PR TITLE
This fixes redcarpet's leaky gem version misrepresentation

### DIFF
--- a/gems/redcarpet/516.yml
+++ b/gems/redcarpet/516.yml
@@ -11,4 +11,4 @@ description: |
 leaky_versions:
   - "< 3.3.3"
 patched_versions:
-  - ">= 3.3"
+  - ">= 3.3.3"


### PR DESCRIPTION
Hey,

This PR will fix `bundler-leak` so that it starts reporting that redcarpet v3.3.2 is leaky.

It fixes https://github.com/rubymem/bundler-leak/issues/34. 

Please check it out.

Thanks! 
