### PR TITLE
Reporting a stale socket leak (memory leak + FD starvation) in Ethon

### DIFF
--- a/gems/ethon/194.yml
+++ b/gems/ethon/194.yml
@@ -1,0 +1,15 @@
+---
+gem: ethon
+date: 2021-05-28
+url: https://github.com/typhoeus/ethon/issues/194
+title: Stale socket leak in Ethon
+description: Some cleanup code in Ethon is not called when the object is garbage collected,
+  leaking stale sockets in CLOSE_WAIT state indefinitely. The impact is a memory leak
+  + file description starvation.
+unaffected_versions:
+- "<= 0.12.0"
+related_links:
+- 'Commit introducing the issue: https://github.com/typhoeus/ethon/commit/b4899b952f85d089358f599c71b0cf7b03db6c39'
+- 'First report about stale socket: https://github.com/typhoeus/ethon/issues/194'
+- 'Reverted in https://github.com/typhoeus/ethon/pull/195/files'
+- 'Second report about memory leak: https://github.com/typhoeus/ethon/issues/198'


### PR DESCRIPTION
See https://github.com/typhoeus/ethon/issues/194 and https://github.com/typhoeus/ethon/issues/198 for a bit more details
The revert is in master but no gem released yet (`0.14.0` is latest when I write this, and it's impacted).
:heavy_check_mark: specs are passing

FTR I tried submitting this through the form (https://www.rubymem.com/advisories/preview) but I get a 500 every time.