### PR TITLE
Update ethon memory leak with patched version (follows #29)

### DIFF
--- a/gems/ethon/194.yml
+++ b/gems/ethon/194.yml
@@ -8,6 +8,8 @@ description: Some cleanup code in Ethon is not called when the object is garbage
   + file description starvation.
 unaffected_versions:
 - "<= 0.12.0"
+patched_versions:
+- ">= 0.15.0"
 related_links:
 - 'Commit introducing the issue: https://github.com/typhoeus/ethon/commit/b4899b952f85d089358f599c71b0cf7b03db6c39'
 - 'First report about stale socket: https://github.com/typhoeus/ethon/issues/194'


### PR DESCRIPTION
Following #29, the patched version has been released now (`0.15.0`) so we can update this.